### PR TITLE
Documentation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+.crdt-graphs
+Sources/CRDT/Documentation.docc/.docc-build

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ DerivedData/
 .netrc
 .crdt-graphs
 Sources/CRDT/Documentation.docc/.docc-build
+all_symbols.txt
+all_identifiers.txt

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ An implementation of ∂-state based CRDTs (conflict-free replicated data types)
 
 This library implements well-known state-based CRDTs as swift generics, and supplies a replicator to support using CRDTs in your own data models.
 
-- [x] LWW-Register (last write wins register)
 - [x] G-Counter (grow-only counter)
 - [x] PN-Counter (A positive-negative counter)
-- [ ] G-Set (grow-only set)
-- [ ] LWW-Set (last write wins set, biased towards add)
-- [ ] OR-Set (observed-remove set)
+- [x] LWW-Register (last write wins register)
+- [X] G-Set (grow-only set)
+- [X] OR-Set (observed-remove set, with LWW add bias)
+- [ ] OR-Map (observed-remove map, with LWW add or update bias)
 - [ ] Replicator
 
 For more, general, information on CRDTs, see the following sites and papers:

--- a/Sources/CRDT/DeltaCRDT.swift
+++ b/Sources/CRDT/DeltaCRDT.swift
@@ -26,10 +26,10 @@ public protocol DeltaCRDT: Replicable {
     ///
     /// - Parameter state: The optional state of the remote CRDT.
     /// - Returns: The changes to be merged into the CRDT instance that provided the state to converge its state with this instance.
-    func delta(_ state: DeltaState?) -> Delta
+    func delta(_ state: DeltaState?) async -> Delta
 
     /// Merges the given delta into the state of this data type instance.
     ///
     /// - Parameter delta: The incremental, partial state to merge.
-    func mergeDelta(_ delta: Delta) -> Self
+    func mergeDelta(_ delta: Delta) async -> Self
 }

--- a/Sources/CRDT/DeltaCRDT.swift
+++ b/Sources/CRDT/DeltaCRDT.swift
@@ -30,8 +30,7 @@ public protocol DeltaCRDT: Replicable {
     /// - Returns: The changes to be merged into the CRDT instance that provided the state to converge its state with this instance.
     func delta(_ state: DeltaState?) async -> Delta
 
-    /// Merges the given delta into the state of this data type instance.
-    ///
+    /// Returns a new instance of a CRDT with the delta you provide merged into the current CRDT.
     /// - Parameter delta: The incremental, partial state to merge.
     func mergeDelta(_ delta: Delta) async -> Self
 }

--- a/Sources/CRDT/DeltaCRDT.swift
+++ b/Sources/CRDT/DeltaCRDT.swift
@@ -9,8 +9,10 @@
 /// state to be presented from another type, which is then used to calculate the delta's needed to bring the
 /// state up to a converged status with the replica that provided the state.
 ///
-/// - SeeAlso: [Delta State Replicated Data Types](https://arxiv.org/abs/1603.01529)
-/// - SeeAlso: [Efficient Synchronization of State-based CRDTs](https://arxiv.org/pdf/1803.02750.pdf)
+/// For more information on delta state replication, review the following research papers:
+///
+/// - [Delta State Replicated Data Types](https://arxiv.org/abs/1603.01529)
+/// - [Efficient Synchronization of State-based CRDTs](https://arxiv.org/pdf/1803.02750.pdf)
 public protocol DeltaCRDT: Replicable {
     /// A type that represents minimal state needed to compute a minimal set of differences that still results in converging CRDTs.
     associatedtype DeltaState
@@ -18,7 +20,7 @@ public protocol DeltaCRDT: Replicable {
     associatedtype Delta
 
     /// The current state of the CRDT.
-    var state: DeltaState { get }
+    var state: DeltaState { get async }
 
     /// Computes and returns a diff from the current state of the CRDT to be used to update another instance.
     ///

--- a/Sources/CRDT/Documentation.docc/DeltaCRDT.md
+++ b/Sources/CRDT/Documentation.docc/DeltaCRDT.md
@@ -2,10 +2,16 @@
 
 ## Topics
 
-### Creating a GCounter
+### Retrieving the current state of a CRDT
 
-- ``CRDT/DeltaCRDT/Delta``
-- ``CRDT/DeltaCRDT/DeltaState``
-- ``CRDT/DeltaCRDT/delta(_:)``
-- ``CRDT/DeltaCRDT/mergeDelta(_:)``
 - ``CRDT/DeltaCRDT/state``
+- ``CRDT/DeltaCRDT/DeltaState``
+
+### Computing the delta to replicate a CRDT
+
+- ``CRDT/DeltaCRDT/delta(_:)``
+- ``CRDT/DeltaCRDT/Delta``
+
+### Merging the delta to replicate a CRDT
+
+- ``CRDT/DeltaCRDT/mergeDelta(_:)``

--- a/Sources/CRDT/Documentation.docc/DeltaCRDT.md
+++ b/Sources/CRDT/Documentation.docc/DeltaCRDT.md
@@ -1,0 +1,11 @@
+# ``CRDT/DeltaCRDT``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/DeltaCRDT/Delta``
+- ``CRDT/DeltaCRDT/DeltaState``
+- ``CRDT/DeltaCRDT/delta(_:)``
+- ``CRDT/DeltaCRDT/mergeDelta(_:)``
+- ``CRDT/DeltaCRDT/state``

--- a/Sources/CRDT/Documentation.docc/Documentation.md
+++ b/Sources/CRDT/Documentation.docc/Documentation.md
@@ -1,13 +1,49 @@
-# ``CRDT/CRDT``
+# ``CRDT``
 
-<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+Seamlessly, consistently, and asynchronously replicate data. 
 
 ## Overview
 
-<!--@START_MENU_TOKEN@-->Text<!--@END_MENU_TOKEN@-->
+Conflict-free Replicated Data Types (CRDT) are data structures that support conflict-free replication algorithms.
+To enable this functionality, CRDT types internally manage history and state relevant to the type of data structure.
+
+The implementations in this library are state-based CRDTs (written as `CvRDT` in research papers), represented by conformance to the ``CRDT/Replicable`` protocol.
+Types that conform to the ``CRDT/DeltaCRDT`` protocol, provide the implementation for ∂-state based CRDTs, which optimizes the data transfer needed to replicate between the types.
+The data types supported in this package are optimized versions of well known CRDT data types and algorithms, including:
+
+CRDT Type | Description
+--- | ---
+``CRDT/GCounter`` | A grow-only counter.
+``CRDT/PNCounter`` | A PN-Counter that both increments and decrements.
+``CRDT/LWWRegister`` | A Last Write Wins register.
+``CRDT/GSet`` | A grow-only set.
+``CRDT/ORSet`` | An Observed-Removed set
+
+For more information on CRDTs and their algorithms, see the [CRDT.tech website](https://crdt.tech), or
+[Wikipedia's page on CRDTs](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type).
 
 ## Topics
 
-### <!--@START_MENU_TOKEN@-->Group<!--@END_MENU_TOKEN@-->
+### Counters
 
-- <!--@START_MENU_TOKEN@-->``Symbol``<!--@END_MENU_TOKEN@-->
+- ``CRDT/GCounter``
+- ``CRDT/PNCounter``
+
+### Registers
+
+- ``CRDT/LWWRegister``
+
+### Sets
+
+- ``CRDT/GSet``
+- ``CRDT/ORSet``
+
+### Supporting Types
+
+- ``CRDT/LamportTimestamp``
+- ``CRDT/WallclockTimestamp``
+
+- ``CRDT/Replicable``
+- ``CRDT/PartiallyOrderable``
+- ``CRDT/DeltaCRDT``
+- ``CRDT/ApproxSizeable``

--- a/Sources/CRDT/Documentation.docc/GCounter.md
+++ b/Sources/CRDT/Documentation.docc/GCounter.md
@@ -2,16 +2,33 @@
 
 ## Topics
 
-### Creating a GCounter
+### Creating a Counter
 
-- ``CRDT/GCounter/!=(_:_:)``
-- ``CRDT/GCounter/delta(_:)``
-- ``CRDT/GCounter/increment()``
 - ``CRDT/GCounter/init(_:actorID:)``
-- ``CRDT/GCounter/init(from:)``
-- ``CRDT/GCounter/mergeDelta(_:)``
-- ``CRDT/GCounter/merged(with:)``
-- ``CRDT/GCounter/sizeInBytes()``
-- ``CRDT/GCounter/state``
+
+### Inspecting a Counter
+
 - ``CRDT/GCounter/value``
+
+### Incrementing the Counter
+
+- ``CRDT/GCounter/increment()``
+
+### Replicating Counters
+
+- ``CRDT/GCounter/merged(with:)``
+
+### Delta-based Replicating
+
+- ``CRDT/GCounter/state``
+- ``CRDT/GCounter/delta(_:)``
+- ``CRDT/GCounter/mergeDelta(_:)``
+
+### Decoding a Counter
+
+- ``CRDT/GCounter/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/GCounter/sizeInBytes()``
 

--- a/Sources/CRDT/Documentation.docc/GCounter.md
+++ b/Sources/CRDT/Documentation.docc/GCounter.md
@@ -1,0 +1,17 @@
+# ``CRDT/GCounter``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/GCounter/!=(_:_:)``
+- ``CRDT/GCounter/delta(_:)``
+- ``CRDT/GCounter/increment()``
+- ``CRDT/GCounter/init(_:actorID:)``
+- ``CRDT/GCounter/init(from:)``
+- ``CRDT/GCounter/mergeDelta(_:)``
+- ``CRDT/GCounter/merged(with:)``
+- ``CRDT/GCounter/sizeInBytes()``
+- ``CRDT/GCounter/state``
+- ``CRDT/GCounter/value``
+

--- a/Sources/CRDT/Documentation.docc/GSet.md
+++ b/Sources/CRDT/Documentation.docc/GSet.md
@@ -1,0 +1,26 @@
+# ``CRDT/GSet``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/GSet/!=(_:_:)``
+- ``CRDT/GSet/GSetDelta``
+- ``CRDT/GSet/GSetDelta/sizeInBytes()``
+- ``CRDT/GSet/GSetState``
+- ``CRDT/GSet/GSetState/!=(_:_:)``
+- ``CRDT/GSet/GSetState/init(from:)``
+- ``CRDT/GSet/GSetState/sizeInBytes()``
+- ``CRDT/GSet/contains(_:)``
+- ``CRDT/GSet/count``
+- ``CRDT/GSet/delta(_:)``
+- ``CRDT/GSet/init(actorId:_:)``
+- ``CRDT/GSet/init(actorId:clock:)``
+- ``CRDT/GSet/init(from:)``
+- ``CRDT/GSet/insert(_:)``
+- ``CRDT/GSet/mergeDelta(_:)``
+- ``CRDT/GSet/merged(with:)``
+- ``CRDT/GSet/sizeInBytes()``
+- ``CRDT/GSet/state``
+- ``CRDT/GSet/values``
+

--- a/Sources/CRDT/Documentation.docc/GSet.md
+++ b/Sources/CRDT/Documentation.docc/GSet.md
@@ -2,25 +2,36 @@
 
 ## Topics
 
-### Creating a GCounter
+### Creating a Set
 
-- ``CRDT/GSet/!=(_:_:)``
-- ``CRDT/GSet/GSetDelta``
-- ``CRDT/GSet/GSetDelta/sizeInBytes()``
-- ``CRDT/GSet/GSetState``
-- ``CRDT/GSet/GSetState/!=(_:_:)``
-- ``CRDT/GSet/GSetState/init(from:)``
-- ``CRDT/GSet/GSetState/sizeInBytes()``
+- ``CRDT/GSet/init(actorId:clock:)``
+- ``CRDT/GSet/init(actorId:clock:_:)``
+
+### Inspecting the Set
+
+- ``CRDT/GSet/values``
 - ``CRDT/GSet/contains(_:)``
 - ``CRDT/GSet/count``
-- ``CRDT/GSet/delta(_:)``
-- ``CRDT/GSet/init(actorId:_:)``
-- ``CRDT/GSet/init(actorId:clock:)``
-- ``CRDT/GSet/init(from:)``
-- ``CRDT/GSet/insert(_:)``
-- ``CRDT/GSet/mergeDelta(_:)``
-- ``CRDT/GSet/merged(with:)``
-- ``CRDT/GSet/sizeInBytes()``
-- ``CRDT/GSet/state``
-- ``CRDT/GSet/values``
 
+### Growing the Set
+
+- ``CRDT/GSet/insert(_:)``
+
+### Replicating a Set
+
+- ``CRDT/GSet/merged(with:)``
+
+### Delta-based Replicating
+
+- ``CRDT/GSet/state``
+- ``CRDT/GSet/delta(_:)``
+- ``CRDT/GSet/mergeDelta(_:)``
+- ``CRDT/GSet/GSetDelta``
+
+### Decoding a Set
+
+- ``CRDT/GSet/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/LWWRegister/sizeInBytes()``

--- a/Sources/CRDT/Documentation.docc/GSet_GSetDelta.md
+++ b/Sources/CRDT/Documentation.docc/GSet_GSetDelta.md
@@ -1,0 +1,12 @@
+# ``CRDT/GSet/GSetDelta``
+
+## Topics
+
+### Decoding an Atom
+
+- ``CRDT/GSet/GSetDelta/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/GSet/GSetDelta/sizeInBytes()``
+

--- a/Sources/CRDT/Documentation.docc/GSet_GSetState.md
+++ b/Sources/CRDT/Documentation.docc/GSet_GSetState.md
@@ -1,0 +1,14 @@
+# ``CRDT/GSet/GSetState``
+
+## Topics
+
+### Decoding a GSet State
+
+- ``CRDT/GSet/GSetState/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/GSet/GSetState/sizeInBytes()``
+
+
+

--- a/Sources/CRDT/Documentation.docc/LWWRegister.md
+++ b/Sources/CRDT/Documentation.docc/LWWRegister.md
@@ -1,0 +1,23 @@
+# ``CRDT/LWWRegister``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/LWWRegister/!=(_:_:)``
+- ``CRDT/LWWRegister/Atom``
+- ``CRDT/LWWRegister/Atom/!=(_:_:)``
+- ``CRDT/LWWRegister/Atom/_=(_:_:)``
+- ``CRDT/LWWRegister/Atom/id-63d9``
+- ``CRDT/LWWRegister/Atom/id-9o6m3``
+- ``CRDT/LWWRegister/Atom/init(from:)``
+- ``CRDT/LWWRegister/Atom/sizeInBytes()``
+- ``CRDT/LWWRegister/delta(_:)``
+- ``CRDT/LWWRegister/init(_:actorID:timestamp:)``
+- ``CRDT/LWWRegister/init(from:)``
+- ``CRDT/LWWRegister/mergeDelta(_:)``
+- ``CRDT/LWWRegister/merged(with:)``
+- ``CRDT/LWWRegister/sizeInBytes()``
+- ``CRDT/LWWRegister/state``
+- ``CRDT/LWWRegister/value``
+

--- a/Sources/CRDT/Documentation.docc/LWWRegister.md
+++ b/Sources/CRDT/Documentation.docc/LWWRegister.md
@@ -2,22 +2,29 @@
 
 ## Topics
 
-### Creating a GCounter
+### Creating a Register
 
-- ``CRDT/LWWRegister/!=(_:_:)``
-- ``CRDT/LWWRegister/Atom``
-- ``CRDT/LWWRegister/Atom/!=(_:_:)``
-- ``CRDT/LWWRegister/Atom/_=(_:_:)``
-- ``CRDT/LWWRegister/Atom/id-63d9``
-- ``CRDT/LWWRegister/Atom/id-9o6m3``
-- ``CRDT/LWWRegister/Atom/init(from:)``
-- ``CRDT/LWWRegister/Atom/sizeInBytes()``
-- ``CRDT/LWWRegister/delta(_:)``
 - ``CRDT/LWWRegister/init(_:actorID:timestamp:)``
-- ``CRDT/LWWRegister/init(from:)``
-- ``CRDT/LWWRegister/mergeDelta(_:)``
-- ``CRDT/LWWRegister/merged(with:)``
-- ``CRDT/LWWRegister/sizeInBytes()``
-- ``CRDT/LWWRegister/state``
+
+### Inspecting or Updating the Register
+
 - ``CRDT/LWWRegister/value``
 
+### Replicating a Register
+
+- ``CRDT/LWWRegister/merged(with:)``
+
+### Delta-based Replicating
+
+- ``CRDT/LWWRegister/state``
+- ``CRDT/LWWRegister/delta(_:)``
+- ``CRDT/LWWRegister/mergeDelta(_:)``
+- ``CRDT/LWWRegister/Atom``
+
+### Decoding a Register
+
+- ``CRDT/LWWRegister/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/LWWRegister/sizeInBytes()``

--- a/Sources/CRDT/Documentation.docc/LWWRegister_Atom.md
+++ b/Sources/CRDT/Documentation.docc/LWWRegister_Atom.md
@@ -1,0 +1,15 @@
+# ``CRDT/LWWRegister/Atom``
+
+## Topics
+
+### Decoding an Atom
+
+- ``CRDT/LWWRegister/Atom/init(from:)``
+
+### Comparing an Atom
+
+- ``CRDT/LWWRegister/Atom/_=(_:_:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/LWWRegister/Atom/sizeInBytes()``

--- a/Sources/CRDT/Documentation.docc/LamportTimestamp.md
+++ b/Sources/CRDT/Documentation.docc/LamportTimestamp.md
@@ -1,0 +1,23 @@
+# ``CRDT/LamportTimestamp``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/LamportTimestamp/!=(_:_:)``
+- ``CRDT/LamportTimestamp/...(_:)-1fd6j``
+- ``CRDT/LamportTimestamp/...(_:)-221op``
+- ``CRDT/LamportTimestamp/...(_:_:)``
+- ``CRDT/LamportTimestamp/.._(_:)``
+- ``CRDT/LamportTimestamp/.._(_:_:)``
+- ``CRDT/LamportTimestamp/_(_:_:)-699eg``
+- ``CRDT/LamportTimestamp/_(_:_:)-8ddr6``
+- ``CRDT/LamportTimestamp/_=(_:_:)-513qg``
+- ``CRDT/LamportTimestamp/_=(_:_:)-8xnuh``
+- ``CRDT/LamportTimestamp/id-3lhvv``
+- ``CRDT/LamportTimestamp/id-46idt``
+- ``CRDT/LamportTimestamp/init(clock:actorId:)``
+- ``CRDT/LamportTimestamp/init(from:)``
+- ``CRDT/LamportTimestamp/sizeInBytes()``
+- ``CRDT/LamportTimestamp/tick()``
+

--- a/Sources/CRDT/Documentation.docc/LamportTimestamp.md
+++ b/Sources/CRDT/Documentation.docc/LamportTimestamp.md
@@ -2,22 +2,24 @@
 
 ## Topics
 
-### Creating a GCounter
+### Creating a Lamport Timestamp
 
-- ``CRDT/LamportTimestamp/!=(_:_:)``
-- ``CRDT/LamportTimestamp/...(_:)-1fd6j``
-- ``CRDT/LamportTimestamp/...(_:)-221op``
-- ``CRDT/LamportTimestamp/...(_:_:)``
-- ``CRDT/LamportTimestamp/.._(_:)``
-- ``CRDT/LamportTimestamp/.._(_:_:)``
-- ``CRDT/LamportTimestamp/_(_:_:)-699eg``
-- ``CRDT/LamportTimestamp/_(_:_:)-8ddr6``
-- ``CRDT/LamportTimestamp/_=(_:_:)-513qg``
-- ``CRDT/LamportTimestamp/_=(_:_:)-8xnuh``
+- ``CRDT/LamportTimestamp/init(clock:actorId:)``
+
+### Incrementing a Timestamp
+
+- ``CRDT/LamportTimestamp/tick()``
+
+### Inspecting a Timestamp
+
 - ``CRDT/LamportTimestamp/id-3lhvv``
 - ``CRDT/LamportTimestamp/id-46idt``
-- ``CRDT/LamportTimestamp/init(clock:actorId:)``
+
+### Decoding a Timestamp
+
 - ``CRDT/LamportTimestamp/init(from:)``
+
+### Debugging and Optimization Methods
+
 - ``CRDT/LamportTimestamp/sizeInBytes()``
-- ``CRDT/LamportTimestamp/tick()``
 

--- a/Sources/CRDT/Documentation.docc/ORSet.md
+++ b/Sources/CRDT/Documentation.docc/ORSet.md
@@ -1,0 +1,29 @@
+# ``CRDT/ORSet``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/ORSet/!=(_:_:)``
+- ``CRDT/ORSet/Metadata``
+- ``CRDT/ORSet/Metadata/!=(_:_:)``
+- ``CRDT/ORSet/Metadata/init(from:)``
+- ``CRDT/ORSet/Metadata/sizeInBytes()``
+- ``CRDT/ORSet/ORSetDelta``
+- ``CRDT/ORSet/ORSetDelta/sizeInBytes()``
+- ``CRDT/ORSet/ORSetState``
+- ``CRDT/ORSet/ORSetState/sizeInBytes()``
+- ``CRDT/ORSet/contains(_:)``
+- ``CRDT/ORSet/count``
+- ``CRDT/ORSet/delta(_:)``
+- ``CRDT/ORSet/init(actorId:)``
+- ``CRDT/ORSet/init(actorId:_:)``
+- ``CRDT/ORSet/init(from:)``
+- ``CRDT/ORSet/insert(_:)``
+- ``CRDT/ORSet/mergeDelta(_:)``
+- ``CRDT/ORSet/merged(with:)``
+- ``CRDT/ORSet/remove(_:)``
+- ``CRDT/ORSet/sizeInBytes()``
+- ``CRDT/ORSet/state``
+- ``CRDT/ORSet/values``
+

--- a/Sources/CRDT/Documentation.docc/ORSet.md
+++ b/Sources/CRDT/Documentation.docc/ORSet.md
@@ -2,28 +2,39 @@
 
 ## Topics
 
-### Creating a GCounter
+### Creating a Set
 
-- ``CRDT/ORSet/!=(_:_:)``
-- ``CRDT/ORSet/Metadata``
-- ``CRDT/ORSet/Metadata/!=(_:_:)``
-- ``CRDT/ORSet/Metadata/init(from:)``
-- ``CRDT/ORSet/Metadata/sizeInBytes()``
-- ``CRDT/ORSet/ORSetDelta``
-- ``CRDT/ORSet/ORSetDelta/sizeInBytes()``
-- ``CRDT/ORSet/ORSetState``
-- ``CRDT/ORSet/ORSetState/sizeInBytes()``
+- ``CRDT/ORSet/init(actorId:clock:)``
+- ``CRDT/ORSet/init(actorId:clock:_:)``
+
+### Inspecting the Set
+
+- ``CRDT/ORSet/values``
 - ``CRDT/ORSet/contains(_:)``
 - ``CRDT/ORSet/count``
-- ``CRDT/ORSet/delta(_:)``
-- ``CRDT/ORSet/init(actorId:)``
-- ``CRDT/ORSet/init(actorId:_:)``
-- ``CRDT/ORSet/init(from:)``
-- ``CRDT/ORSet/insert(_:)``
-- ``CRDT/ORSet/mergeDelta(_:)``
-- ``CRDT/ORSet/merged(with:)``
-- ``CRDT/ORSet/remove(_:)``
-- ``CRDT/ORSet/sizeInBytes()``
-- ``CRDT/ORSet/state``
-- ``CRDT/ORSet/values``
 
+### Updating the Set
+
+- ``CRDT/ORSet/insert(_:)``
+- ``CRDT/ORSet/remove(_:)``
+
+### Replicating a Set
+
+- ``CRDT/ORSet/merged(with:)``
+
+### Delta-based Replicating
+
+- ``CRDT/ORSet/state``
+- ``CRDT/ORSet/ORSetState``
+- ``CRDT/ORSet/delta(_:)``
+- ``CRDT/ORSet/ORSetDelta``
+- ``CRDT/ORSet/mergeDelta(_:)``
+
+
+### Decoding a Set
+
+- ``CRDT/ORSet/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/ORSet/sizeInBytes()``

--- a/Sources/CRDT/Documentation.docc/ORSet_ORSetDelta.md
+++ b/Sources/CRDT/Documentation.docc/ORSet_ORSetDelta.md
@@ -1,0 +1,13 @@
+# ``CRDT/ORSet/ORSetDelta``
+
+## Topics
+
+### Decoding an ORSet Delta
+
+- ``CRDT/GSet/GSetDelta/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/ORSet/ORSetDelta/sizeInBytes()``
+
+

--- a/Sources/CRDT/Documentation.docc/ORSet_ORSetState.md
+++ b/Sources/CRDT/Documentation.docc/ORSet_ORSetState.md
@@ -1,0 +1,12 @@
+# ``CRDT/ORSet/ORSetState``
+
+## Topics
+
+### Decoding an ORSet State
+
+- ``CRDT/ORSet/ORSetState/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/ORSet/ORSetState/sizeInBytes()``
+

--- a/Sources/CRDT/Documentation.docc/PNCounter.md
+++ b/Sources/CRDT/Documentation.docc/PNCounter.md
@@ -1,0 +1,20 @@
+# ``CRDT/PNCounter``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/PNCounter/!=(_:_:)``
+- ``CRDT/PNCounter/PNCounterState``
+- ``CRDT/PNCounter/PNCounterState/sizeInBytes()``
+- ``CRDT/PNCounter/decrement()``
+- ``CRDT/PNCounter/delta(_:)``
+- ``CRDT/PNCounter/increment()``
+- ``CRDT/PNCounter/init(_:actorID:)``
+- ``CRDT/PNCounter/init(from:)``
+- ``CRDT/PNCounter/mergeDelta(_:)``
+- ``CRDT/PNCounter/merged(with:)``
+- ``CRDT/PNCounter/sizeInBytes()``
+- ``CRDT/PNCounter/state``
+- ``CRDT/PNCounter/value``
+

--- a/Sources/CRDT/Documentation.docc/PNCounter.md
+++ b/Sources/CRDT/Documentation.docc/PNCounter.md
@@ -2,19 +2,35 @@
 
 ## Topics
 
-### Creating a GCounter
+### Creating a Counter
 
-- ``CRDT/PNCounter/!=(_:_:)``
-- ``CRDT/PNCounter/PNCounterState``
-- ``CRDT/PNCounter/PNCounterState/sizeInBytes()``
-- ``CRDT/PNCounter/decrement()``
-- ``CRDT/PNCounter/delta(_:)``
-- ``CRDT/PNCounter/increment()``
 - ``CRDT/PNCounter/init(_:actorID:)``
-- ``CRDT/PNCounter/init(from:)``
-- ``CRDT/PNCounter/mergeDelta(_:)``
-- ``CRDT/PNCounter/merged(with:)``
-- ``CRDT/PNCounter/sizeInBytes()``
-- ``CRDT/PNCounter/state``
+
+### Inspecting a Counter
+
 - ``CRDT/PNCounter/value``
+
+### Adjusting the Counter
+
+- ``CRDT/PNCounter/increment()``
+- ``CRDT/PNCounter/decrement()``
+
+### Replicating Counters
+
+- ``CRDT/PNCounter/merged(with:)``
+
+### Delta-based Replicating
+
+- ``CRDT/PNCounter/state``
+- ``CRDT/PNCounter/delta(_:)``
+- ``CRDT/PNCounter/mergeDelta(_:)``
+- ``CRDT/PNCounter/PNCounterState``
+
+### Decoding a Counter
+
+- ``CRDT/PNCounter/init(from:)``
+
+### Debugging and Optimization Methods
+
+- ``CRDT/PNCounter/sizeInBytes()``
 

--- a/Sources/CRDT/Documentation.docc/PartiallyOrderable.md
+++ b/Sources/CRDT/Documentation.docc/PartiallyOrderable.md
@@ -2,7 +2,7 @@
 
 ## Topics
 
-### Creating a GCounter
+### Comparing a Partially Orderable type
 
 - ``CRDT/PartiallyOrderable/_=(_:_:)``
 

--- a/Sources/CRDT/Documentation.docc/PartiallyOrderable.md
+++ b/Sources/CRDT/Documentation.docc/PartiallyOrderable.md
@@ -1,0 +1,8 @@
+# ``CRDT/PartiallyOrderable``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/PartiallyOrderable/_=(_:_:)``
+

--- a/Sources/CRDT/Documentation.docc/Replicable.md
+++ b/Sources/CRDT/Documentation.docc/Replicable.md
@@ -2,7 +2,7 @@
 
 ## Topics
 
-### Creating a GCounter
+### Directly Replicating a CRDT
 
 - ``CRDT/Replicable/merged(with:)``
 

--- a/Sources/CRDT/Documentation.docc/Replicable.md
+++ b/Sources/CRDT/Documentation.docc/Replicable.md
@@ -1,0 +1,8 @@
+# ``CRDT/Replicable``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/Replicable/merged(with:)``
+

--- a/Sources/CRDT/Documentation.docc/WallclockTimestamp.md
+++ b/Sources/CRDT/Documentation.docc/WallclockTimestamp.md
@@ -1,0 +1,22 @@
+# ``CRDT/WallclockTimestamp``
+
+## Topics
+
+### Creating a GCounter
+
+- ``CRDT/WallclockTimestamp/!=(_:_:)``
+- ``CRDT/WallclockTimestamp/...(_:)-3gtja``
+- ``CRDT/WallclockTimestamp/...(_:)-4eldr``
+- ``CRDT/WallclockTimestamp/...(_:_:)``
+- ``CRDT/WallclockTimestamp/.._(_:)``
+- ``CRDT/WallclockTimestamp/.._(_:_:)``
+- ``CRDT/WallclockTimestamp/_(_:_:)-33zg8``
+- ``CRDT/WallclockTimestamp/_(_:_:)-363nt``
+- ``CRDT/WallclockTimestamp/_=(_:_:)-2iea6``
+- ``CRDT/WallclockTimestamp/_=(_:_:)-5sdir``
+- ``CRDT/WallclockTimestamp/id-1tb67``
+- ``CRDT/WallclockTimestamp/id-6oxj2``
+- ``CRDT/WallclockTimestamp/init(actorId:timestamp:)``
+- ``CRDT/WallclockTimestamp/init(from:)``
+- ``CRDT/WallclockTimestamp/sizeInBytes()``
+

--- a/Sources/CRDT/GCounter.swift
+++ b/Sources/CRDT/GCounter.swift
@@ -40,11 +40,11 @@ extension GCounter: DeltaCRDT {
         _storage
     }
 
-    public func delta(_: UInt?) -> UInt {
+    public func delta(_: UInt?) async -> UInt {
         _storage
     }
 
-    public func mergeDelta(_ delta: UInt) -> Self {
+    public func mergeDelta(_ delta: UInt) async -> Self {
         var copy = self
         copy._storage = max(_storage, delta)
         return copy

--- a/Sources/CRDT/GCounter.swift
+++ b/Sources/CRDT/GCounter.swift
@@ -37,7 +37,9 @@ extension GCounter: Replicable {
 
 extension GCounter: DeltaCRDT {
     public var state: UInt {
-        _storage
+        get async {
+            _storage
+        }
     }
 
     public func delta(_: UInt?) async -> UInt {

--- a/Sources/CRDT/GCounter.swift
+++ b/Sources/CRDT/GCounter.swift
@@ -52,9 +52,7 @@ extension GCounter: DeltaCRDT {
 }
 
 extension GCounter: Codable where ActorID: Codable {}
-
 extension GCounter: Equatable {}
-
 extension GCounter: Hashable {}
 
 #if DEBUG

--- a/Sources/CRDT/GCounter.swift
+++ b/Sources/CRDT/GCounter.swift
@@ -10,12 +10,12 @@ import Foundation
 public struct GCounter<ActorID: Hashable & Comparable> {
     private var _storage: UInt
     internal let selfId: ActorID
-    
+
     /// The counter's value.
     public var value: UInt {
         _storage
     }
-    
+
     /// Increments the counter.
     @discardableResult
     public mutating func increment() -> UInt {
@@ -24,7 +24,7 @@ public struct GCounter<ActorID: Hashable & Comparable> {
         }
         return _storage
     }
-    
+
     /// Creates a new counter.
     /// - Parameters:
     ///   - value: An optional parameter to set an initial counter value.
@@ -52,7 +52,7 @@ extension GCounter: DeltaCRDT {
             _storage
         }
     }
-    
+
     /// Computes and returns a diff from the current state of the counter to be used to update another instance.
     ///
     /// - Parameter state: The optional state of the remote CRDT.

--- a/Sources/CRDT/GCounter.swift
+++ b/Sources/CRDT/GCounter.swift
@@ -10,17 +10,25 @@ import Foundation
 public struct GCounter<ActorID: Hashable & Comparable> {
     private var _storage: UInt
     internal let selfId: ActorID
-
+    
+    /// The counter's value.
     public var value: UInt {
         _storage
     }
-
-    public mutating func increment() {
+    
+    /// Increments the counter.
+    @discardableResult
+    public mutating func increment() -> UInt {
         if _storage != UInt.max {
             _storage += 1
         }
+        return _storage
     }
-
+    
+    /// Creates a new counter.
+    /// - Parameters:
+    ///   - value: An optional parameter to set an initial counter value.
+    ///   - actorID: The identity of the collaborator for the counter.
     public init(_ value: UInt = 0, actorID: ActorID) {
         selfId = actorID
         _storage = value
@@ -28,6 +36,8 @@ public struct GCounter<ActorID: Hashable & Comparable> {
 }
 
 extension GCounter: Replicable {
+    /// Returns a new counter by merging two counter instances.
+    /// - Parameter other: The counter to merge.
     public func merged(with other: Self) -> Self {
         var copy = self
         copy._storage = max(value, other._storage)
@@ -36,16 +46,24 @@ extension GCounter: Replicable {
 }
 
 extension GCounter: DeltaCRDT {
+    /// The current state of the CRDT.
     public var state: UInt {
         get async {
             _storage
         }
     }
-
+    
+    /// Computes and returns a diff from the current state of the counter to be used to update another instance.
+    ///
+    /// - Parameter state: The optional state of the remote CRDT.
+    /// - Returns: The changes to be merged into the counter instance that provided the state to converge its state with this instance.
     public func delta(_: UInt?) async -> UInt {
         _storage
     }
 
+    /// Merges the given delta into the state of this data type instance.
+    ///
+    /// - Parameter delta: The incremental, partial state to merge.
     public func mergeDelta(_ delta: UInt) async -> Self {
         var copy = self
         copy._storage = max(_storage, delta)

--- a/Sources/CRDT/GCounter.swift
+++ b/Sources/CRDT/GCounter.swift
@@ -61,8 +61,7 @@ extension GCounter: DeltaCRDT {
         _storage
     }
 
-    /// Merges the given delta into the state of this data type instance.
-    ///
+    /// Returns a new instance of a counter with the delta you provide merged into the current counter.
     /// - Parameter delta: The incremental, partial state to merge.
     public func mergeDelta(_ delta: UInt) async -> Self {
         var copy = self

--- a/Sources/CRDT/GSet.swift
+++ b/Sources/CRDT/GSet.swift
@@ -10,24 +10,24 @@ import Foundation
 public struct GSet<ActorID: Hashable & Comparable, T: Hashable> {
     private var _storage: Set<T>
     internal var currentTimestamp: LamportTimestamp<ActorID>
-    
+
     /// The set of values.
     public var values: Set<T> {
         _storage
     }
-    
+
     /// The number of items in the set.
     public var count: Int {
         _storage.count
     }
-    
+
     /// Inserts a new value into the set.
     /// - Parameter value: The value to insert.
     public mutating func insert(_ value: T) {
         _storage.insert(value)
         currentTimestamp.tick()
     }
-    
+
     /// Returns a Boolean value that indicates whether the set contains the value you provide.
     /// - Parameter value: The value to compare.
     public func contains(_ value: T) -> Bool {
@@ -72,7 +72,7 @@ extension GSet: DeltaCRDT {
     public struct GSetState {
         let values: Set<T>
     }
-    
+
     /// A struct that represents the differences to be merged to replicate the set.
     public struct GSetDelta {
         let lamportClock: LamportTimestamp<ActorID>

--- a/Sources/CRDT/GSet.swift
+++ b/Sources/CRDT/GSet.swift
@@ -62,7 +62,9 @@ extension GSet: DeltaCRDT {
 
     // var state: DeltaState { get }
     public var state: GSetState {
-        GSetState(values: _storage)
+        get async {
+            GSetState(values: _storage)
+        }
     }
 
     // func delta(_ state: DeltaState?) -> [Delta]

--- a/Sources/CRDT/GSet.swift
+++ b/Sources/CRDT/GSet.swift
@@ -66,7 +66,7 @@ extension GSet: DeltaCRDT {
     }
 
     // func delta(_ state: DeltaState?) -> [Delta]
-    public func delta(_ otherState: GSetState?) -> GSetDelta {
+    public func delta(_ otherState: GSetState?) async -> GSetDelta {
         if let otherState = otherState {
             var diff = _storage
             for val in _storage.intersection(otherState.values) {
@@ -79,7 +79,7 @@ extension GSet: DeltaCRDT {
     }
 
     // func mergeDelta(_ delta: [Delta]) -> Self
-    public func mergeDelta(_ delta: GSetDelta) -> Self {
+    public func mergeDelta(_ delta: GSetDelta) async -> Self {
         var copy = self
         // Merging two grow-only sets is (conveniently) the union of the two sets
         copy._storage = values.union(delta.values)

--- a/Sources/CRDT/GSet.swift
+++ b/Sources/CRDT/GSet.swift
@@ -33,8 +33,8 @@ public struct GSet<ActorID: Hashable & Comparable, T: Hashable> {
         _storage = Set<T>()
     }
 
-    public init(actorId: ActorID, _ elements: [T]) {
-        self = .init(actorId: actorId)
+    public init(actorId: ActorID, clock: UInt64 = 0, _ elements: [T]) {
+        self = .init(actorId: actorId, clock: clock)
         elements.forEach { self.insert($0) }
     }
 }
@@ -91,16 +91,16 @@ extension GSet: DeltaCRDT {
 }
 
 extension GSet: Codable where T: Codable, ActorID: Codable {}
-
 extension GSet.GSetState: Codable where T: Codable, ActorID: Codable {}
+extension GSet.GSetDelta: Codable where T: Codable, ActorID: Codable {}
 
 extension GSet: Equatable where T: Equatable {}
-
 extension GSet.GSetState: Equatable where T: Equatable {}
+extension GSet.GSetDelta: Equatable where T: Equatable {}
 
 extension GSet: Hashable where T: Hashable {}
-
 extension GSet.GSetState: Hashable where T: Hashable {}
+extension GSet.GSetDelta: Hashable where T: Hashable {}
 
 #if DEBUG
     extension GSet: ApproxSizeable {

--- a/Sources/CRDT/LWWRegister.swift
+++ b/Sources/CRDT/LWWRegister.swift
@@ -67,11 +67,11 @@ extension LWWRegister: DeltaCRDT {
         _storage
     }
 
-    public func delta(_: Atom?) -> Atom {
+    public func delta(_: Atom?) async -> Atom {
         _storage
     }
 
-    public func mergeDelta(_ delta: Atom) -> Self {
+    public func mergeDelta(_ delta: Atom) async -> Self {
         var newLWW = self
         newLWW._storage = _storage <= delta ? delta : _storage
         return newLWW

--- a/Sources/CRDT/LWWRegister.swift
+++ b/Sources/CRDT/LWWRegister.swift
@@ -64,7 +64,9 @@ extension LWWRegister: DeltaCRDT {
 //    public typealias DeltaState = Self.Atom
 //    public typealias Delta = Self.Atom
     public var state: Atom {
-        _storage
+        get async {
+            _storage
+        }
     }
 
     public func delta(_: Atom?) async -> Atom {

--- a/Sources/CRDT/LWWRegister.swift
+++ b/Sources/CRDT/LWWRegister.swift
@@ -22,7 +22,7 @@ public struct LWWRegister<ActorID: Hashable & Comparable, T> {
         }
 
         // MARK: Conformance of LWWRegister.Atom to PartiallyOrderable
-        
+
         /// Returns a Boolean value that indicates if the atom is less-than or equal to another atom.
         /// - Parameters:
         ///   - lhs: The first atom to compare.
@@ -36,7 +36,7 @@ public struct LWWRegister<ActorID: Hashable & Comparable, T> {
 
     private var _storage: Atom
     internal let selfId: ActorID
-    
+
     /// The value of the register.
     public var value: T {
         get {

--- a/Sources/CRDT/LWWRegister.swift
+++ b/Sources/CRDT/LWWRegister.swift
@@ -12,14 +12,9 @@ import Foundation
 /// - SeeAlso: [A comprehensive study of Convergent and Commutative Replicated Data Types](https://hal.inria.fr/inria-00555588/document)” by Marc Shapiro, Nuno Preguiça, Carlos Baquero, and Marek Zawirski (2011).
 public struct LWWRegister<ActorID: Hashable & Comparable, T> {
     /// The replicated state structure for LWWRegister
-    public struct Atom: Identifiable, PartiallyOrderable {
+    public struct Atom {
         internal var value: T
         internal var clockId: WallclockTimestamp<ActorID>
-
-        /// The identity of the counter metadata (atom) computed from the actor Id and a current timestamp.
-        public var id: String {
-            clockId.id
-        }
 
         init(value: T, id: ActorID, timestamp: TimeInterval = Date().timeIntervalSinceReferenceDate) {
             self.value = value
@@ -84,15 +79,12 @@ extension LWWRegister: DeltaCRDT {
 }
 
 extension LWWRegister: Codable where T: Codable, ActorID: Codable {}
-
 extension LWWRegister.Atom: Codable where T: Codable, ActorID: Codable {}
 
 extension LWWRegister: Equatable where T: Equatable {}
-
 extension LWWRegister.Atom: Equatable where T: Equatable {}
 
 extension LWWRegister: Hashable where T: Hashable {}
-
 extension LWWRegister.Atom: Hashable where T: Hashable {}
 
 #if DEBUG

--- a/Sources/CRDT/ORSet.swift
+++ b/Sources/CRDT/ORSet.swift
@@ -13,7 +13,7 @@ import Foundation
 /// Annette Bieniusa, Marek Zawirski, Nuno Preguiça, Marc Shapiro, Carlos Baquero, Valter Balegas, and Sérgio Duarte (2012).
 /// arXiv:[1210.3368](https://arxiv.org/abs/1210.3368)
 public struct ORSet<ActorID: Hashable & Comparable, T: Hashable> {
-    public struct Metadata {
+    internal struct Metadata {
         var isDeleted: Bool
         var lamportTimestamp: LamportTimestamp<ActorID>
 
@@ -26,13 +26,13 @@ public struct ORSet<ActorID: Hashable & Comparable, T: Hashable> {
     internal var currentTimestamp: LamportTimestamp<ActorID>
     internal var metadataByValue: [T: Metadata]
 
-    public init(actorId: ActorID) {
+    public init(actorId: ActorID, clock: UInt64 = 0) {
         metadataByValue = .init()
-        currentTimestamp = .init(actorId: actorId)
+        currentTimestamp = .init(clock: clock, actorId: actorId)
     }
 
-    public init(actorId: ActorID, _ elements: [T]) {
-        self = .init(actorId: actorId)
+    public init(actorId: ActorID, clock: UInt64 = 0, _ elements: [T]) {
+        self = .init(actorId: actorId, clock: clock)
         elements.forEach { self.insert($0) }
     }
 
@@ -183,16 +183,19 @@ extension ORSet: DeltaCRDT {
 }
 
 extension ORSet: Codable where T: Codable, ActorID: Codable {}
-
 extension ORSet.Metadata: Codable where T: Codable, ActorID: Codable {}
+extension ORSet.ORSetState: Codable where T: Codable, ActorID: Codable {}
+extension ORSet.ORSetDelta: Codable where T: Codable, ActorID: Codable {}
 
 extension ORSet: Equatable where T: Equatable {}
-
 extension ORSet.Metadata: Equatable where T: Equatable {}
+extension ORSet.ORSetState: Equatable where T: Equatable {}
+extension ORSet.ORSetDelta: Equatable where T: Equatable {}
 
 extension ORSet: Hashable where T: Hashable {}
-
 extension ORSet.Metadata: Hashable where T: Hashable {}
+extension ORSet.ORSetState: Hashable where T: Hashable {}
+extension ORSet.ORSetDelta: Hashable where T: Hashable {}
 
 #if DEBUG
     extension ORSet.Metadata: ApproxSizeable {

--- a/Sources/CRDT/ORSet.swift
+++ b/Sources/CRDT/ORSet.swift
@@ -142,7 +142,7 @@ extension ORSet: DeltaCRDT {
     ///
     /// - Parameter state: The optional state of the remote ORSet.
     /// - Returns: The changes to be merged into the ORSet instance that provided the state to converge its state with this instance.
-    public func delta(_ otherInstanceState: ORSetState?) -> ORSetDelta {
+    public func delta(_ otherInstanceState: ORSetState?) async -> ORSetDelta {
         // In the case of a null state being provided, the delta is all current values and their metadata:
         guard let maxClockValueByActor: [ActorID: UInt64] = otherInstanceState?.maxClockValueByActor else {
             return ORSetDelta(updates: metadataByValue)
@@ -168,7 +168,7 @@ extension ORSet: DeltaCRDT {
     // func mergeDelta(_ delta: Delta) -> Self
     /// Returns a new instance of an ORSet with the delta you provide merged into the current ORSet.
     /// - Parameter delta: The incremental, partial state to merge.
-    public func mergeDelta(_ delta: ORSetDelta) -> Self {
+    public func mergeDelta(_ delta: ORSetDelta) async -> Self {
         var copy = self
         for (valueKey, metadata) in delta.updates {
             copy.metadataByValue[valueKey] = metadata

--- a/Sources/CRDT/ORSet.swift
+++ b/Sources/CRDT/ORSet.swift
@@ -56,7 +56,7 @@ public struct ORSet<ActorID: Hashable & Comparable, T: Hashable> {
     public func contains(_ value: T) -> Bool {
         !(metadataByValue[value]?.isDeleted ?? true)
     }
-    
+
     /// The number of items in the set.
     public var count: Int {
         metadataByValue.filter { !$1.isDeleted }.count
@@ -80,7 +80,7 @@ public struct ORSet<ActorID: Hashable & Comparable, T: Hashable> {
 
         return isNewInsert
     }
-    
+
     /// Removes a value from the set.
     /// - Parameter value: The value to remove.
     /// - Returns: The value removed from the set, or `nil` if the value didn't exist.

--- a/Sources/CRDT/PNCounter.swift
+++ b/Sources/CRDT/PNCounter.swift
@@ -90,8 +90,7 @@ extension PNCounter: DeltaCRDT {
         PNCounterState(pos: pos_value, neg: neg_value)
     }
 
-    /// Merges the given delta into the state of this data type instance.
-    ///
+    /// Returns a new instance of an counter with the delta you provide merged into the current counter.
     /// - Parameter delta: The incremental, partial state to merge.
     public func mergeDelta(_ delta: PNCounterState) async -> Self {
         var copy = self

--- a/Sources/CRDT/PNCounter.swift
+++ b/Sources/CRDT/PNCounter.swift
@@ -61,7 +61,9 @@ extension PNCounter: DeltaCRDT {
     }
 
     public var state: PNCounterState {
-        PNCounterState(pos: pos_value, neg: neg_value)
+        get async {
+            PNCounterState(pos: pos_value, neg: neg_value)
+        }
     }
 
     public func delta(_: PNCounterState?) async -> PNCounterState {

--- a/Sources/CRDT/PNCounter.swift
+++ b/Sources/CRDT/PNCounter.swift
@@ -12,6 +12,7 @@ public struct PNCounter<ActorID: Hashable & Comparable> {
     internal var neg_value: UInt
     internal let selfId: ActorID
 
+    /// The counter's value.
     public var value: Int {
         // ternary operator, since I can never entirely remember the sequence:
         // expression ? valueIfTrue : valueIfFalse
@@ -23,14 +24,24 @@ public struct PNCounter<ActorID: Hashable & Comparable> {
         return pos_int - neg_int
     }
 
-    public mutating func increment() {
+    /// Increments the counter.
+    @discardableResult
+    public mutating func increment() -> Int {
         pos_value += 1
+        return self.value
     }
 
-    public mutating func decrement() {
+    /// Decrements the counter.
+    @discardableResult
+    public mutating func decrement() -> Int {
         neg_value += 1
+        return self.value
     }
-
+    
+    /// Creates a new counter.
+    /// - Parameters:
+    ///   - value: An optional parameter to set an initial counter value.
+    ///   - actorID: The identity of the collaborator for the counter.
     public init(_ value: Int = 0, actorID: ActorID) {
         selfId = actorID
         if value >= 0 {
@@ -44,6 +55,8 @@ public struct PNCounter<ActorID: Hashable & Comparable> {
 }
 
 extension PNCounter: Replicable {
+    /// Returns a new counter by merging two counter instances.
+    /// - Parameter other: The counter to merge.
     public func merged(with other: Self) -> Self {
         var copy = self
         copy.pos_value = max(other.pos_value, pos_value)
@@ -55,21 +68,31 @@ extension PNCounter: Replicable {
 extension PNCounter: DeltaCRDT {
 //    public typealias DeltaState = Self.Atom
 //    public typealias Delta = Self.Atom
+    
+    /// A struct that represents the state of a PNCounter.
     public struct PNCounterState {
         let pos: UInt
         let neg: UInt
     }
 
+    /// The current state of the CRDT.
     public var state: PNCounterState {
         get async {
             PNCounterState(pos: pos_value, neg: neg_value)
         }
     }
 
+    /// Computes and returns a diff from the current state of the counter to be used to update another instance.
+    ///
+    /// - Parameter state: The optional state of the remote CRDT.
+    /// - Returns: The changes to be merged into the counter instance that provided the state to converge its state with this instance.
     public func delta(_: PNCounterState?) async -> PNCounterState {
         PNCounterState(pos: pos_value, neg: neg_value)
     }
 
+    /// Merges the given delta into the state of this data type instance.
+    ///
+    /// - Parameter delta: The incremental, partial state to merge.
     public func mergeDelta(_ delta: PNCounterState) async -> Self {
         var copy = self
         copy.pos_value = max(delta.pos, pos_value)

--- a/Sources/CRDT/PNCounter.swift
+++ b/Sources/CRDT/PNCounter.swift
@@ -77,10 +77,13 @@ extension PNCounter: DeltaCRDT {
 }
 
 extension PNCounter: Codable where ActorID: Codable {}
+extension PNCounter.PNCounterState: Codable where ActorID: Codable {}
 
 extension PNCounter: Equatable {}
+extension PNCounter.PNCounterState: Equatable {}
 
 extension PNCounter: Hashable {}
+extension PNCounter.PNCounterState: Hashable {}
 
 #if DEBUG
     extension PNCounter: ApproxSizeable {

--- a/Sources/CRDT/PNCounter.swift
+++ b/Sources/CRDT/PNCounter.swift
@@ -28,16 +28,16 @@ public struct PNCounter<ActorID: Hashable & Comparable> {
     @discardableResult
     public mutating func increment() -> Int {
         pos_value += 1
-        return self.value
+        return value
     }
 
     /// Decrements the counter.
     @discardableResult
     public mutating func decrement() -> Int {
         neg_value += 1
-        return self.value
+        return value
     }
-    
+
     /// Creates a new counter.
     /// - Parameters:
     ///   - value: An optional parameter to set an initial counter value.
@@ -68,7 +68,7 @@ extension PNCounter: Replicable {
 extension PNCounter: DeltaCRDT {
 //    public typealias DeltaState = Self.Atom
 //    public typealias Delta = Self.Atom
-    
+
     /// A struct that represents the state of a PNCounter.
     public struct PNCounterState {
         let pos: UInt

--- a/Sources/CRDT/PNCounter.swift
+++ b/Sources/CRDT/PNCounter.swift
@@ -64,11 +64,11 @@ extension PNCounter: DeltaCRDT {
         PNCounterState(pos: pos_value, neg: neg_value)
     }
 
-    public func delta(_: PNCounterState?) -> PNCounterState {
+    public func delta(_: PNCounterState?) async -> PNCounterState {
         PNCounterState(pos: pos_value, neg: neg_value)
     }
 
-    public func mergeDelta(_ delta: PNCounterState) -> Self {
+    public func mergeDelta(_ delta: PNCounterState) async -> Self {
         var copy = self
         copy.pos_value = max(delta.pos, pos_value)
         copy.neg_value = max(delta.neg, neg_value)

--- a/Sources/CRDT/Replicable.swift
+++ b/Sources/CRDT/Replicable.swift
@@ -10,6 +10,8 @@
 /// - Associative ((a -merged-> b) -merged-> c) = (a -merged-> (b -merged-> c))
 /// - Idempotent (a -merged-> a = a)
 public protocol Replicable {
+    /// Returns a new CRDT by merging two CRDT instances.
+    /// - Parameter other: The CRDT to merge.
     func merged(with other: Self) -> Self
 }
 

--- a/Tests/CRDTTests/GCounterTests.swift
+++ b/Tests/CRDTTests/GCounterTests.swift
@@ -71,8 +71,8 @@ final class GCounterTests: XCTestCase {
         XCTAssertEqual(a, d)
     }
 
-    func testDeltaState_state() {
-        let atom = a.state
+    func testDeltaState_state() async {
+        let atom = await a.state
         XCTAssertNotNil(atom)
         XCTAssertEqual(atom, a.value)
     }

--- a/Tests/CRDTTests/GCounterTests.swift
+++ b/Tests/CRDTTests/GCounterTests.swift
@@ -77,21 +77,21 @@ final class GCounterTests: XCTestCase {
         XCTAssertEqual(atom, a.value)
     }
 
-    func testDeltaState_delta() {
-        let a_nil_delta = a.delta(nil)
+    func testDeltaState_delta() async {
+        let a_nil_delta = await a.delta(nil)
         // print(a_nil_delta)
         XCTAssertNotNil(a_nil_delta)
         XCTAssertEqual(a_nil_delta, 1)
 
-        let a_delta = a.delta(b.state)
+        let a_delta = await a.delta(b.state)
         XCTAssertNotNil(a_delta)
         XCTAssertEqual(a_delta, 1)
     }
 
-    func testDeltaState_mergeDelta() {
+    func testDeltaState_mergeDelta() async {
         // equiv direct merge
         // let c = a.merged(with: b)
-        let c = a.mergeDelta(b.delta(a.state))
+        let c = await a.mergeDelta(await b.delta(a.state))
         XCTAssertEqual(c.value, b.value)
     }
 }

--- a/Tests/CRDTTests/GSetTests.swift
+++ b/Tests/CRDTTests/GSetTests.swift
@@ -70,30 +70,30 @@ final class GSetTests: XCTestCase {
         XCTAssertEqual(state.values, a.values)
     }
 
-    func testDeltaState_delta() {
-        let a_nil_delta = a.delta(nil)
+    func testDeltaState_delta() async {
+        let a_nil_delta = await a.delta(nil)
         // print(a_nil_delta)
         XCTAssertNotNil(a_nil_delta)
         XCTAssertEqual(a_nil_delta.values, [])
 
-        let a_delta = a.delta(b.state)
+        let a_delta = await a.delta(b.state)
         XCTAssertNotNil(a_delta)
         XCTAssertEqual(a_delta.values, [])
     }
 
-    func testDeltaState_mergeDeltas() {
+    func testDeltaState_mergeDeltas() async {
         // equiv direct merge
         // let c = a.merged(with: b)
-        let delta = b.delta(a.state)
-        let c = a.mergeDelta(delta)
+        let delta = await b.delta(a.state)
+        let c = await a.mergeDelta(delta)
         XCTAssertEqual(c.values, b.values)
     }
 
-    func testDeltaState_mergeDelta() {
+    func testDeltaState_mergeDelta() async {
         // equiv direct merge
         // let c = a.merged(with: b)
-        let delta = b.delta(a.state)
-        let c = a.mergeDelta(delta)
+        let delta = await b.delta(a.state)
+        let c = await a.mergeDelta(delta)
         XCTAssertEqual(c.values, b.values)
     }
 }

--- a/Tests/CRDTTests/GSetTests.swift
+++ b/Tests/CRDTTests/GSetTests.swift
@@ -64,8 +64,8 @@ final class GSetTests: XCTestCase {
         XCTAssertEqual(b, d)
     }
 
-    func testDeltaState_state() {
-        let state = a.state
+    func testDeltaState_state() async {
+        let state = await a.state
         XCTAssertNotNil(state)
         XCTAssertEqual(state.values, a.values)
     }

--- a/Tests/CRDTTests/LWWRegisterTests.swift
+++ b/Tests/CRDTTests/LWWRegisterTests.swift
@@ -68,7 +68,6 @@ final class LWWRegisterTests: XCTestCase {
         let atom = a.state
         XCTAssertNotNil(atom)
         XCTAssertEqual(atom.value, a.value)
-        XCTAssertNotNil(atom.id)
         XCTAssertEqual(atom.clockId.actorId, a.selfId)
     }
 

--- a/Tests/CRDTTests/LWWRegisterTests.swift
+++ b/Tests/CRDTTests/LWWRegisterTests.swift
@@ -71,25 +71,25 @@ final class LWWRegisterTests: XCTestCase {
         XCTAssertEqual(atom.clockId.actorId, a.selfId)
     }
 
-    func testDeltaState_delta() {
-        let a_nil_delta = a.delta(nil)
+    func testDeltaState_delta() async {
+        let a_nil_delta = await a.delta(nil)
         // print(a_nil_delta)
         XCTAssertNotNil(a_nil_delta)
         XCTAssertEqual(a_nil_delta.value, 1)
         XCTAssertEqual(a_nil_delta, a.state)
 
-        let a_delta = a.delta(b.state)
+        let a_delta = await a.delta(b.state)
         XCTAssertNotNil(a_delta)
         XCTAssertEqual(a_delta.value, 1)
         XCTAssertEqual(a_delta, a.state)
     }
 
-    func testDeltaState_mergeDelta() {
+    func testDeltaState_mergeDelta() async {
         // equiv direct merge
         // let c = a.merged(with: b)
-        let delta = b.delta(a.state)
+        let delta = await b.delta(a.state)
         XCTAssertNotNil(delta)
-        let c = a.mergeDelta(delta)
+        let c = await a.mergeDelta(delta)
         XCTAssertEqual(c.value, b.value)
     }
 }

--- a/Tests/CRDTTests/LWWRegisterTests.swift
+++ b/Tests/CRDTTests/LWWRegisterTests.swift
@@ -64,8 +64,8 @@ final class LWWRegisterTests: XCTestCase {
         XCTAssertEqual(a, d)
     }
 
-    func testDeltaState_state() {
-        let atom = a.state
+    func testDeltaState_state() async {
+        let atom = await a.state
         XCTAssertNotNil(atom)
         XCTAssertEqual(atom.value, a.value)
         XCTAssertEqual(atom.clockId.actorId, a.selfId)
@@ -76,12 +76,13 @@ final class LWWRegisterTests: XCTestCase {
         // print(a_nil_delta)
         XCTAssertNotNil(a_nil_delta)
         XCTAssertEqual(a_nil_delta.value, 1)
-        XCTAssertEqual(a_nil_delta, a.state)
+        let a_state = await a.state
+        XCTAssertEqual(a_nil_delta, a_state)
 
         let a_delta = await a.delta(b.state)
         XCTAssertNotNil(a_delta)
         XCTAssertEqual(a_delta.value, 1)
-        XCTAssertEqual(a_delta, a.state)
+        XCTAssertEqual(a_delta, a_state)
     }
 
     func testDeltaState_mergeDelta() async {

--- a/Tests/CRDTTests/ORSetTests.swift
+++ b/Tests/CRDTTests/ORSetTests.swift
@@ -100,33 +100,33 @@ final class ORSetTests: XCTestCase {
         XCTAssertEqual(Array(state.maxClockValueByActor.values), [a.currentTimestamp.clock])
     }
 
-    func testDeltaState_nilDelta() {
-        let a_nil_delta = a.delta(nil)
+    func testDeltaState_nilDelta() async {
+        let a_nil_delta = await a.delta(nil)
         // print(a_nil_delta)
         XCTAssertNotNil(a_nil_delta)
         XCTAssertEqual(a_nil_delta.updates.count, 1)
         XCTAssertEqual(a_nil_delta.updates, a.metadataByValue)
     }
 
-    func testDeltaState_delta() {
-        let a_delta = a.delta(b.state)
+    func testDeltaState_delta() async {
+        let a_delta = await a.delta(b.state)
         XCTAssertEqual(a_delta.updates.count, 1)
         XCTAssertEqual(a_delta.updates, a.metadataByValue)
     }
 
-    func testDeltaState_mergeDeltas() {
+    func testDeltaState_mergeDeltas() async {
         // equiv direct merge
         // let c = a.merged(with: b)
-        let delta = b.delta(a.state)
-        let c = a.mergeDelta(delta)
+        let delta = await b.delta(a.state)
+        let c = await a.mergeDelta(delta)
         XCTAssertEqual(c.values, b.values)
     }
 
-    func testDeltaState_mergeDelta() {
+    func testDeltaState_mergeDelta() async {
         // equiv direct merge
         // let c = a.merged(with: b)
-        let delta = b.delta(a.state)
-        let c = a.mergeDelta(delta)
+        let delta = await b.delta(a.state)
+        let c = await a.mergeDelta(delta)
         XCTAssertEqual(c.values, b.values)
     }
 }

--- a/Tests/CRDTTests/ORSetTests.swift
+++ b/Tests/CRDTTests/ORSetTests.swift
@@ -93,8 +93,8 @@ final class ORSetTests: XCTestCase {
         XCTAssertEqual(b, d)
     }
 
-    func testDeltaState_state() {
-        let state = a.state
+    func testDeltaState_state() async {
+        let state = await a.state
         XCTAssertNotNil(state)
         XCTAssertEqual(Array(state.maxClockValueByActor.keys), [a.currentTimestamp.actorId])
         XCTAssertEqual(Array(state.maxClockValueByActor.values), [a.currentTimestamp.clock])

--- a/Tests/CRDTTests/PNCounterTests.swift
+++ b/Tests/CRDTTests/PNCounterTests.swift
@@ -93,23 +93,23 @@ final class PNCounterTests: XCTestCase {
         XCTAssertEqual(a.value, Int(atom.pos) - Int(atom.neg))
     }
 
-    func testDeltaState_delta() {
-        let a_nil_delta = a.delta(nil)
+    func testDeltaState_delta() async {
+        let a_nil_delta = await a.delta(nil)
         // print(a_nil_delta)
         XCTAssertNotNil(a_nil_delta)
         XCTAssertEqual(a_nil_delta.pos, 1)
         XCTAssertEqual(a_nil_delta.neg, 0)
 
-        let a_delta = a.delta(b.state)
+        let a_delta = await a.delta(b.state)
         XCTAssertNotNil(a_delta)
         XCTAssertEqual(a_delta.pos, 1)
         XCTAssertEqual(a_delta.neg, 0)
     }
 
-    func testDeltaState_mergeDelta() {
+    func testDeltaState_mergeDelta() async {
         // equiv direct merge
         // let c = a.merged(with: b)
-        let c = a.mergeDelta(b.delta(a.state))
+        let c = await a.mergeDelta(await b.delta(a.state))
         XCTAssertEqual(c.value, b.value)
     }
 }

--- a/Tests/CRDTTests/PNCounterTests.swift
+++ b/Tests/CRDTTests/PNCounterTests.swift
@@ -87,8 +87,8 @@ final class PNCounterTests: XCTestCase {
         XCTAssertEqual(a, d)
     }
 
-    func testDeltaState_state() {
-        let atom = a.state
+    func testDeltaState_state() async {
+        let atom = await a.state
         XCTAssertNotNil(atom)
         XCTAssertEqual(a.value, Int(atom.pos) - Int(atom.neg))
     }

--- a/Tests/CRDTTests/grokTests.swift
+++ b/Tests/CRDTTests/grokTests.swift
@@ -18,11 +18,8 @@ final class grokTests: XCTestCase {
         XCTAssertTrue((1, 5) == (1, 5))
     }
 
-    let x: UInt = 1
-    let y: UInt = 2
-
     func testMinMax() throws {
-        let a = Int.min + 1 // Int.min doesn't convert to UInt - just one more than it can handle...
+        let a = Int.min + 1 // Int.min doesn't convert to UInt - its just one more than it can handle...
         let b = abs(a)
         // print(b)
         let c = UInt(b)
@@ -30,27 +27,30 @@ final class grokTests: XCTestCase {
         // print(c)
     }
 
-    func SKIPtestUIntOverflowLimits() throws {
-//        do {
-        let result = x - y // swift runtime overflow, can't catch & handle...
-        print(result)
-//        } catch {
-//            print("Unexpected error: \(error).")
-//        }
-    }
-
-    func SKIPtestIntConversion() throws {
-        let intMax = Int.max
-        var converted = UInt(intMax)
-        converted += 1
-
-//        do {
-        let result = Int(converted) // Runtime fatalerror here
-        print(result)
-//        } catch {
-//            print("Unexpected error: \(error).")
-//        }
-    }
+//    let x: UInt = 1
+//    let y: UInt = 2
+//
+//    func SKIPtestUIntOverflowLimits() throws {
+    ////        do {
+//        let result = x - y // swift runtime overflow, can't catch & handle...
+//        print(result)
+    ////        } catch {
+    ////            print("Unexpected error: \(error).")
+    ////        }
+//    }
+//
+//    func SKIPtestIntConversion() throws {
+//        let intMax = Int.max
+//        var converted = UInt(intMax)
+//        converted += 1
+//
+    ////        do {
+//        let result = Int(converted) // Runtime fatalerror here
+//        print(result)
+    ////        } catch {
+    ////            print("Unexpected error: \(error).")
+    ////        }
+//    }
 
     #if DEBUG
         func testSizing() throws {
@@ -95,5 +95,18 @@ final class grokTests: XCTestCase {
             print("Delta size of Set1 merging into Set2: \(gset_2.delta(gset_1.state).sizeInBytes())")
             print("Delta size of Set2 merging into Set1: \(gset_1.delta(gset_2.state).sizeInBytes())")
         }
+
+        func testORSetSizing() throws {
+            let orset_1 = ORSet(actorId: UInt(31), [1, 2, 3, 4])
+            let orset_2 = ORSet(actorId: UInt(31), [4, 5])
+
+            print("ORSet1(4 elements, UInt actorId) = \(orset_1.sizeInBytes())")
+            print("ORSet2(2 elements, UInt actorId) = \(orset_2.sizeInBytes())")
+            print("ORSet1's state size: \(orset_1.state.sizeInBytes())")
+            print("ORSet2's state size: \(orset_1.state.sizeInBytes())")
+            print("Delta size of Set1 merging into Set2: \(orset_2.delta(orset_1.state).sizeInBytes())")
+            print("Delta size of Set2 merging into Set1: \(orset_1.delta(orset_2.state).sizeInBytes())")
+        }
+
     #endif
 }

--- a/Tests/CRDTTests/grokTests.swift
+++ b/Tests/CRDTTests/grokTests.swift
@@ -84,7 +84,7 @@ final class grokTests: XCTestCase {
             print("Size of GCounter state with UUID.uuidString as actorID: \(pncounter_uuid_string.state.sizeInBytes())")
         }
 
-        func testGSetSizing() throws {
+        func testGSetSizing() async throws {
             let gset_1 = GSet(actorId: UInt(31), [1, 2, 3, 4])
             let gset_2 = GSet(actorId: UInt(31), [4, 5])
 
@@ -92,11 +92,11 @@ final class grokTests: XCTestCase {
             print("GSet2(2 elements, UInt actorId) = \(gset_2.sizeInBytes())")
             print("GSet1's state size: \(gset_1.state.sizeInBytes())")
             print("GSet2's state size: \(gset_1.state.sizeInBytes())")
-            print("Delta size of Set1 merging into Set2: \(gset_2.delta(gset_1.state).sizeInBytes())")
-            print("Delta size of Set2 merging into Set1: \(gset_1.delta(gset_2.state).sizeInBytes())")
+            print("Delta size of Set1 merging into Set2: \(await gset_2.delta(gset_1.state).sizeInBytes())")
+            print("Delta size of Set2 merging into Set1: \(await gset_1.delta(gset_2.state).sizeInBytes())")
         }
 
-        func testORSetSizing() throws {
+        func testORSetSizing() async throws {
             let orset_1 = ORSet(actorId: UInt(31), [1, 2, 3, 4])
             let orset_2 = ORSet(actorId: UInt(31), [4, 5])
 
@@ -104,8 +104,8 @@ final class grokTests: XCTestCase {
             print("ORSet2(2 elements, UInt actorId) = \(orset_2.sizeInBytes())")
             print("ORSet1's state size: \(orset_1.state.sizeInBytes())")
             print("ORSet2's state size: \(orset_1.state.sizeInBytes())")
-            print("Delta size of Set1 merging into Set2: \(orset_2.delta(orset_1.state).sizeInBytes())")
-            print("Delta size of Set2 merging into Set1: \(orset_1.delta(orset_2.state).sizeInBytes())")
+            print("Delta size of Set1 merging into Set2: \(await orset_2.delta(orset_1.state).sizeInBytes())")
+            print("Delta size of Set2 merging into Set1: \(await orset_1.delta(orset_2.state).sizeInBytes())")
         }
 
     #endif

--- a/Tests/CRDTTests/grokTests.swift
+++ b/Tests/CRDTTests/grokTests.swift
@@ -53,35 +53,35 @@ final class grokTests: XCTestCase {
 //    }
 
     #if DEBUG
-        func testSizing() throws {
+        func testSizing() async throws {
             let gcounter_uint_hash = GCounter(actorID: UInt(32))
             print("Size of GCounter with UInt as actorID: \(gcounter_uint_hash.sizeInBytes())")
-            print("Size of GCounter state with UInt as actorID: \(gcounter_uint_hash.state.sizeInBytes())")
+            print("Size of GCounter state with UInt as actorID: \(await gcounter_uint_hash.state.sizeInBytes())")
 
             let gcounter_uint8_hash = GCounter(actorID: UInt8(32))
             print("Size of GCounter with UInt8 as actorID: \(gcounter_uint8_hash.sizeInBytes())")
-            print("Size of GCounter state with UInt8 as actorID: \(gcounter_uint8_hash.state.sizeInBytes())")
+            print("Size of GCounter state with UInt8 as actorID: \(await gcounter_uint8_hash.state.sizeInBytes())")
 
             let gcounter_uuid_hash = GCounter(actorID: UUID().hashValue)
             print("Size of GCounter with UUID.hashvalue as actorID: \(gcounter_uuid_hash.sizeInBytes())")
-            print("Size of GCounter state with UUID.hashvalue as actorID: \(gcounter_uuid_hash.state.sizeInBytes())")
+            print("Size of GCounter state with UUID.hashvalue as actorID: \(await gcounter_uuid_hash.state.sizeInBytes())")
 
             let gcounter_uuid_string = GCounter(actorID: UUID().uuidString)
             print("Size of GCounter with UUID.uuidString as actorID: \(gcounter_uuid_string.sizeInBytes())")
-            print("Size of GCounter state with UUID.uuidString as actorID: \(gcounter_uuid_string.state.sizeInBytes())")
+            print("Size of GCounter state with UUID.uuidString as actorID: \(await gcounter_uuid_string.state.sizeInBytes())")
 
             let pncounter_uint_hash = PNCounter(actorID: UInt(32))
             print("Size of GCounter with UInt as actorID: \(pncounter_uint_hash.sizeInBytes())")
-            print("Size of GCounter state with UInt as actorID: \(pncounter_uint_hash.state.sizeInBytes())")
+            print("Size of GCounter state with UInt as actorID: \(await pncounter_uint_hash.state.sizeInBytes())")
             let pncounter_uint8_hash = PNCounter(actorID: UInt8(32))
             print("Size of GCounter with UInt8 as actorID: \(pncounter_uint8_hash.sizeInBytes())")
-            print("Size of GCounter state with UInt8 as actorID: \(pncounter_uint8_hash.state.sizeInBytes())")
+            print("Size of GCounter state with UInt8 as actorID: \(await pncounter_uint8_hash.state.sizeInBytes())")
             let pncounter_uuid_hash = PNCounter(actorID: UUID().hashValue)
             print("Size of GCounter with UUID.hashvalue as actorID: \(pncounter_uuid_hash.sizeInBytes())")
-            print("Size of GCounter state with UUID.hashvalue as actorID: \(pncounter_uuid_hash.state.sizeInBytes())")
+            print("Size of GCounter state with UUID.hashvalue as actorID: \(await pncounter_uuid_hash.state.sizeInBytes())")
             let pncounter_uuid_string = PNCounter(actorID: UUID().uuidString)
             print("Size of GCounter with UUID.uuidString as actorID: \(pncounter_uuid_string.sizeInBytes())")
-            print("Size of GCounter state with UUID.uuidString as actorID: \(pncounter_uuid_string.state.sizeInBytes())")
+            print("Size of GCounter state with UUID.uuidString as actorID: \(await pncounter_uuid_string.state.sizeInBytes())")
         }
 
         func testGSetSizing() async throws {
@@ -90,8 +90,8 @@ final class grokTests: XCTestCase {
 
             print("GSet1(4 elements, UInt actorId) = \(gset_1.sizeInBytes())")
             print("GSet2(2 elements, UInt actorId) = \(gset_2.sizeInBytes())")
-            print("GSet1's state size: \(gset_1.state.sizeInBytes())")
-            print("GSet2's state size: \(gset_1.state.sizeInBytes())")
+            print("GSet1's state size: \(await gset_1.state.sizeInBytes())")
+            print("GSet2's state size: \(await gset_2.state.sizeInBytes())")
             print("Delta size of Set1 merging into Set2: \(await gset_2.delta(gset_1.state).sizeInBytes())")
             print("Delta size of Set2 merging into Set1: \(await gset_1.delta(gset_2.state).sizeInBytes())")
         }
@@ -102,8 +102,8 @@ final class grokTests: XCTestCase {
 
             print("ORSet1(4 elements, UInt actorId) = \(orset_1.sizeInBytes())")
             print("ORSet2(2 elements, UInt actorId) = \(orset_2.sizeInBytes())")
-            print("ORSet1's state size: \(orset_1.state.sizeInBytes())")
-            print("ORSet2's state size: \(orset_1.state.sizeInBytes())")
+            print("ORSet1's state size: \(await orset_1.state.sizeInBytes())")
+            print("ORSet2's state size: \(await orset_2.state.sizeInBytes())")
             print("Delta size of Set1 merging into Set2: \(await orset_2.delta(orset_1.state).sizeInBytes())")
             print("Delta size of Set2 merging into Set1: \(await orset_1.delta(orset_2.state).sizeInBytes())")
         }

--- a/docbuild.bash
+++ b/docbuild.bash
@@ -45,7 +45,7 @@ export DOCC_JSON_PRETTYPRINT=YES
      --allow-writing-to-directory ./docs \
      generate-documentation \
      --fallback-bundle-identifier com.github.heckj.CRDT \
-     --target SwiftVizScale \
+     --target CRDT \
      --output-path ./docs \
      --emit-digest \
      --disable-indexing \


### PR DESCRIPTION
initial state:
```
   --- Experimental coverage output enabled. ---
                | Abstract        | Curated         | Code Listing
Types           | 80% (16/20)     | 55% (11/20)     | 0.0% (0/20)
Members         | 45% (36/80)     | 45% (36/80)     | 0.0% (0/80)
Globals         | 0.0% (0/31)     | 77% (24/31)     | 0.0% (0/31)
```