### PR TITLE
Additional checking for error states in merging related, and unrelated, CRDT instances

### DIFF
--- a/Sources/CRDT/ApproxSizeable.swift
+++ b/Sources/CRDT/ApproxSizeable.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 #if DEBUG
-    /// A type that reports is approximate memory size, useful for debugging and proofing.
+    /// A type that reports an approximate memory size, useful for debugging and proofing.
     public protocol ApproxSizeable {
         /// Returns the approximate size, in bytes, of the memory used.
         func sizeInBytes() -> Int

--- a/Sources/CRDT/CRDTMergeError.swift
+++ b/Sources/CRDT/CRDTMergeError.swift
@@ -1,0 +1,9 @@
+//
+//  CRDTMergeError.swift
+//
+
+/// Errors related to failures in merging CRDT instances.
+public enum CRDTMergeError: Error {
+    /// The metadata from the remote CRDT conflicts with the local metadata.
+    case conflictingHistory(_ msg: String)
+}

--- a/Sources/CRDT/DeltaCRDT.swift
+++ b/Sources/CRDT/DeltaCRDT.swift
@@ -32,5 +32,8 @@ public protocol DeltaCRDT: Replicable {
 
     /// Returns a new instance of a CRDT with the delta you provide merged into the current CRDT.
     /// - Parameter delta: The incremental, partial state to merge.
-    func mergeDelta(_ delta: Delta) async -> Self
+    ///
+    /// CRDTs that maintain causal history for updates may throw errors if the state included within the delta you provide conflicts
+    /// with the local CRDT's history.
+    func mergeDelta(_ delta: Delta) async throws -> Self
 }

--- a/Sources/CRDT/Documentation.docc/CRDTMergeError.md
+++ b/Sources/CRDT/Documentation.docc/CRDTMergeError.md
@@ -1,0 +1,7 @@
+# ``CRDT/CRDTMergeError``
+
+## Topics
+
+### Conflicting History
+
+- ``CRDT/CRDTMergeError/conflictingHistory(_:)``

--- a/Sources/CRDT/Documentation.docc/DeltaCRDT.md
+++ b/Sources/CRDT/Documentation.docc/DeltaCRDT.md
@@ -15,3 +15,4 @@
 ### Merging the delta to replicate a CRDT
 
 - ``CRDT/DeltaCRDT/mergeDelta(_:)``
+- ``CRDT/CRDTMergeError``

--- a/Sources/CRDT/Documentation.docc/Documentation.md
+++ b/Sources/CRDT/Documentation.docc/Documentation.md
@@ -38,12 +38,18 @@ For more information on CRDTs and their algorithms, see the [CRDT.tech website](
 - ``CRDT/GSet``
 - ``CRDT/ORSet``
 
-### Supporting Types
+### Timestamps
 
 - ``CRDT/LamportTimestamp``
 - ``CRDT/WallclockTimestamp``
 
+### Replication Protocols
+
 - ``CRDT/Replicable``
 - ``CRDT/PartiallyOrderable``
 - ``CRDT/DeltaCRDT``
+- ``CRDT/CRDTMergeError``
+
+### Debugging and Optimization Protocols
+
 - ``CRDT/ApproxSizeable``


### PR DESCRIPTION
Thinking through #13 some more, I realized scenarios where the merge should more likely throw than directly copy without error. The DeltaCRDT protocol has been updated to now support throwing on merging deltas, specifically for the scenario where there is conflicting historical data for the existing CRDT that's merging in a delta.